### PR TITLE
Add descriptions to ErrorType enum and new InvalidCredentials

### DIFF
--- a/src/CodeFlow.Start.Package/WebTransfer/Base/ErrorType.cs
+++ b/src/CodeFlow.Start.Package/WebTransfer/Base/ErrorType.cs
@@ -1,4 +1,6 @@
-﻿namespace CodeFlow.Start.Package.WebTransfer.Base;
+﻿using System.ComponentModel;
+
+namespace CodeFlow.Start.Package.WebTransfer.Base;
 
 /// <summary>
 /// Enum to categorize error types.
@@ -8,10 +10,18 @@ public enum ErrorType
     /// <summary>
     /// Represents an internal system error.
     /// </summary>
+    [Description("Internal error")]
     InternalError = 500,
 
     /// <summary>
     /// Represents a business rule error.
     /// </summary>
-    BusinessRuleError = 400
+    [Description("Business rule error")]
+    BusinessRuleError = 400,
+
+    /// <summary>
+    /// Represents an error when the user is not authenticated.
+    /// </summary>
+    [Description("Invalid credentials")]
+    InvalidCredentials = 401
 }


### PR DESCRIPTION
The `System.ComponentModel` namespace was added to use the `Description` attribute. Descriptions were added to `InternalError` and `BusinessRuleError` in the `ErrorType` enum. A new error type, `InvalidCredentials`, was added to the `ErrorType` enum with a value of 401 and a description of "Invalid credentials".

## Description

<!-- Briefly describe the changes made in this pull request and the reason for them. -->

## Types of Changes

What kind of change does this PR introduce? Mark all that apply with an `x`:

- [ ] Bug fix 🐛
- [ ] New feature ✨
- [x] Enhancement or feature improvement 🔄
- [ ] Refactor 🔧
- [ ] Documentation 📚
- [ ] Other (please specify): 

## Checklist

Before submitting this PR, please verify the following:

- [x] Code follows the project's coding standards and style guides.
- [x] Changes were tested locally to ensure functionality.
- [x] All existing tests pass.
- [x] Documentation has been updated (if applicable).

## Related Issues

<!-- Link any related issues here. -->
Closes #[issue_number]

## Screenshots (if applicable)

<!-- Add screenshots or GIFs to demonstrate the functionality or changes. -->

## Additional Information

<!-- Add any additional context or information that might help with the review process. -->
